### PR TITLE
Need guidance figuring out how to update the ROOT_QUERY array

### DIFF
--- a/apollo-remote-state/client/src/operations/mutations/addTodo.tsx
+++ b/apollo-remote-state/client/src/operations/mutations/addTodo.tsx
@@ -26,9 +26,17 @@ export function useAddTodo () {
   >(
     ADD_TODO,
     {
-      refetchQueries: [{
-        query: GET_ALL_TODOS
-      }]
+      update (cache, { data }) {
+        cache.modify('ROOT_QUERY', {
+          todos (existingTodos, { toReference }) {
+            return [...existingTodos.edges, 
+              //@ts-ignore
+              { __typename: 'TodosEdge', node: toReference(data.addTodo.todo) }
+            ]             
+          }
+        })
+
+      }
     }
   )
   return { mutate, data, error };

--- a/apollo-remote-state/client/src/operations/mutations/deleteTodo.tsx
+++ b/apollo-remote-state/client/src/operations/mutations/deleteTodo.tsx
@@ -39,6 +39,7 @@ export function useDeleteTodo () {
                 return deletedId !== readField('id', edge.node);
               })
             }
+            
             return newTodos;
           }
         });


### PR DESCRIPTION
## Description
In the `addTodo` mutation, I'm adding the newly created todo to the array of objects after it has been normalized in the cache. Unfortunately, the UI doesn't update after it has been changed. Perhaps this is because we are creating a new array of items from the existing one, but I'm not entirely sure.

Printing `__APOLLO_CLIENT__.cache.data.data` shows that a newly created todo item has been added to both the normalized cache in addition to the `ROOT_QUERY`.

**Before adding a new todo**

![Screen Shot 2020-04-07 at 3 36 08 PM](https://user-images.githubusercontent.com/6892666/78711828-a5a32d80-78e5-11ea-91b8-f4b3b63ea3be.png)

**After adding a new todo**

![Screen Shot 2020-04-07 at 3 36 42 PM](https://user-images.githubusercontent.com/6892666/78711845-ab990e80-78e5-11ea-9135-bf066f17fe30.png)

## How to reproduce

Start the in-memory server.

```bash
cd apollo-remote-state/server && npm install && npm run start
```

Start the client-side.

```bash
cd apollo-remote-state/client && npm install && npm run start
```

- Navigate to `http://localhost:3000/`. 
- Print out the cache with `__APOLLO_CLIENT__.cache.data.data`. Observe that there are 3 items, both normalized and in `ROOT_QUERY`.
- Add a new todo.
- Print out the cache with `__APOLLO_CLIENT__.cache.data.data`. Observe that there are 4 items, both normalized and in `ROOT_QUERY`.
- Observe that the UI didn't update.

