### PR TITLE
Newer version of Apollo Client broke the Reactive Var mocks type checking

### DIFF
--- a/apollo-local-state/package-lock.json
+++ b/apollo-local-state/package-lock.json
@@ -5,20 +5,21 @@
   "requires": true,
   "dependencies": {
     "@apollo/client": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.0.1.tgz",
-      "integrity": "sha512-d+3f6ZhPPjnhRzUEHMUtaUfRKpx3cFE6QtLh8yuy0TH9phHuXx4CVWJHfnu8KfJ+MfcC3xiRcw4AaMHC2VwLnw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.2.7.tgz",
+      "integrity": "sha512-4G80jvBLqenCFUhwkHAAHi2ox6Ygq35BkE38yxammqykZm6KE3tVlcEKGOZi0jpiuGJPC6LIQ0d1gtI8ADPtmg==",
       "requires": {
+        "@graphql-typed-document-node/core": "^3.0.0",
         "@types/zen-observable": "^0.8.0",
         "@wry/context": "^0.5.2",
-        "@wry/equality": "^0.1.9",
+        "@wry/equality": "^0.2.0",
         "fast-json-stable-stringify": "^2.0.0",
-        "graphql-tag": "^2.10.4",
+        "graphql-tag": "^2.11.0",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.12.1",
+        "optimism": "^0.13.0",
         "prop-types": "^15.7.2",
-        "symbol-observable": "^1.2.0",
-        "ts-invariant": "^0.4.4",
+        "symbol-observable": "^2.0.0",
+        "ts-invariant": "^0.5.0",
         "tslib": "^1.10.0",
         "zen-observable": "^0.8.14"
       }
@@ -1162,6 +1163,11 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==",
       "dev": true
     },
+    "@graphql-typed-document-node/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg=="
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -1830,9 +1836,9 @@
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
     },
     "@types/zen-observable": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
-      "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.1.tgz",
+      "integrity": "sha512-wmk0xQI6Yy7Fs/il4EpOcflG4uonUpYGqvZARESLc2oy4u69fkatFLbJOeW4Q6awO15P4rduAe6xkwHevpXcUQ=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.21.0",
@@ -2070,9 +2076,9 @@
       }
     },
     "@wry/equality": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
-      "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.2.0.tgz",
+      "integrity": "sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==",
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -6389,9 +6395,9 @@
       }
     },
     "graphql-tag": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.4.tgz",
-      "integrity": "sha512-O7vG5BT3w6Sotc26ybcvLKNTdfr4GfsIVMD+LdYqXCeJIYPRyp8BIsDOUtxw7S1PYvRw5vH3278J2EDezR6mfA=="
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
+      "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
     },
     "growly": {
       "version": "1.3.0",
@@ -9864,9 +9870,9 @@
       }
     },
     "optimism": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.12.1.tgz",
-      "integrity": "sha512-t8I7HM1dw0SECitBYAqFOVHoBAHEQBTeKjIL9y9ImHzAVkdyPK4ifTgM4VJRDtTUY4r/u5Eqxs4XcGPHaoPkeQ==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.13.1.tgz",
+      "integrity": "sha512-16RRVYZe8ODcUqpabpY7Gb91vCAbdhn8FHjlUb2Hqnjjow1j8Z1dlppds+yAsLbreNTVylLC+tNX6DuC2vt3Kw==",
       "requires": {
         "@wry/context": "^0.5.2"
       }
@@ -13524,9 +13530,9 @@
       }
     },
     "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
+      "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA=="
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -13885,9 +13891,9 @@
       }
     },
     "ts-invariant": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
-      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.5.1.tgz",
+      "integrity": "sha512-k3UpDNrBZpqJFnAAkAHNmSHtNuCxcU6xLiziPgalHRKZHme6T6jnKC8CcXDmk1zbHLQM8pc+rNC1Q6FvXMAl+g==",
       "requires": {
         "tslib": "^1.9.3"
       }

--- a/apollo-local-state/package.json
+++ b/apollo-local-state/package.json
@@ -9,7 +9,7 @@
     "react-test-renderer": "^16.8.6"
   },
   "dependencies": {
-    "@apollo/client": "^3.0.1",
+    "@apollo/client": "^3.2.7",
     "@types/jest": "^25.1.3",
     "@types/node": "^13.7.6",
     "@types/react": "^16.9.23",

--- a/apollo-local-state/src/tests/createMockReactiveVar.ts
+++ b/apollo-local-state/src/tests/createMockReactiveVar.ts
@@ -5,12 +5,13 @@ import { ReactiveVar } from "@apollo/client";
 // It's a good idea to do this because then we can test our
 // interaction logic.
 
-export function createMockReactiveVar<T> (defaultValue?: T): ReactiveVar<T> {
+export function createMockReactiveVar<T> (defaultValue?: T): any {
   let currentValue: T | undefined = defaultValue;
 
   return function mockReactiveVar (
     newValue?: T
   ) : T {
+    
     if (newValue) {
       currentValue = newValue;
     }


### PR DESCRIPTION
As mentioned in https://github.com/apollographql/ac3-state-management-examples/issues/26, the newer versions of Apollo Client break the Reactive Var mock type checking in typescript.

This PR fixes that; we get the same semantic behavior by changing the return type to `any`.